### PR TITLE
change download method, remove curl dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pdtools
 Title: Tools to interact with NCBI's Pathogen Detection project
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person("Julian", "Trachsel", , "julestrachsel@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0003-2357-7737"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     tidyr,
     purrr,
     lubridate,
-    curl,
     RCurl,
     tibble,
     Biostrings,

--- a/R/download_tools.R
+++ b/R/download_tools.R
@@ -64,9 +64,9 @@ download_PDD_metadata <- function(organism, PDG, folder_prefix=NULL){
   # print('downloading metadata...')
   # curl_download(url = meta_url, destfile = meta_dest)
   print('downloading amr data...')
-  base::download.file(url = amr_url, destfile = amr_dest)
+  utils::download.file(url = amr_url, destfile = amr_dest)
   print('downloading cluster data...')
-  base::download.file(url = cluster_url, destfile = cluster_dest)
+  utils::download.file(url = cluster_url, destfile = cluster_dest)
 }
 
 

--- a/R/download_tools.R
+++ b/R/download_tools.R
@@ -64,9 +64,9 @@ download_PDD_metadata <- function(organism, PDG, folder_prefix=NULL){
   # print('downloading metadata...')
   # curl_download(url = meta_url, destfile = meta_dest)
   print('downloading amr data...')
-  curl::curl_download(url = amr_url, destfile = amr_dest)
+  base::download.file(url = amr_url, destfile = amr_dest)
   print('downloading cluster data...')
-  curl::curl_download(url = cluster_url, destfile = cluster_dest)
+  base::download.file(url = cluster_url, destfile = cluster_dest)
 }
 
 


### PR DESCRIPTION
was having problems with download functions on Ceres. Changed to using utils::download.file() allows removal of curl (R package) dependency. Hope this works

